### PR TITLE
use protocol relative cdn

### DIFF
--- a/examples/example.html
+++ b/examples/example.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
   <head>
     <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+    <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="../leaflet-iiif.js"></script>
   </head>


### PR DESCRIPTION
Closes #9 

Issues were being seen when a browser or browser plugin was forcing link to be viewed over https. Was requiring Leaflet cdn resources served over https. Now switched to Cloudfare protocol relative cdn resources.
