### PR TITLE
Add in option to proxy tile retrieval

### DIFF
--- a/leaflet-iiif.js
+++ b/leaflet-iiif.js
@@ -25,6 +25,12 @@ L.TileLayer.Iiif = L.TileLayer.extend({
       this._explicitTileSize = true;
     }
 
+    if (typeof options.tileProxyPath !== 'undefined') {
+      this.tileProxyPath = options.tileProxyPath;
+    } else {
+      this.tileProxyPath = null;
+    }
+
     options = L.setOptions(this, options);
     this._infoDeferred = new $.Deferred();
     this._infoUrl = url;
@@ -202,6 +208,10 @@ L.TileLayer.Iiif = L.TileLayer.extend({
   },
 
   _infoToBaseUrl: function() {
+    if (this.tileProxyPath !== null) {
+      return this.tileProxyPath;
+    }
+
     return this._infoUrl.replace('info.json', '');
   },
   _templateUrl: function() {


### PR DESCRIPTION
Thanks for the great plugin. At UNC Libraries we need to proxy both info.json and tile retrieval. It's easy enough to proxy the info.json request by passing it in as the tileLayer path. This pull request adds in an option to proxy the tile retrieval as well, as at least in our case they point to separate paths.
Example Usage:
```JavaScript
var iiifLayers = {'img': L.tileLayer.iiif('jp2Metadata/' + this.options.url + '/IMAGE_JP2000',
     { tileProxyPath: '/jp2Region/' + this.options.url + '/IMAGE_JP2000'})
};
```