### PR TITLE
Add optional error handler for requests that return no data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Option | Type | Default | Description
 `tileSize` | Number | 256 | Tile size (width and height in pixels, assuming tiles are square).
 `fitBounds` | Boolean | true | Automatically center and fit the maps bounds to the added IIIF layer
 `quality` | String | 'default' | [determines whether the image is delivered in color, grayscale or black and white](http://iiif.io/api/image/2.0/#quality) _Note:_ All IIIF servers do not support this parameter.
+`errorHandler` | Function | undefined | Pass a function reference to execute when ajax requests succeed, but the returned data element is empty or undefined.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ var map = L.map('map', {
 L.tileLayer.iiif('http://example.com/iiifimage.jp2/info.json').addTo(map);
 ```
 
+### With error handler option (Passing in your own custom function, as below)
+
+```
+function errorHandler() {
+  $('#viewer').removeClass("not_loaded").height("30px")
+     .html("<div class='error'>Sorry, an error occurred while loading the image.</div>");
+}
+
+L.tileLayer.iiif('http://example.com/iiifimage.jp2/info.json', {errorHandler: errorHandler}).addTo(map);
+```
+
 Thanks to [klokantech/iiifviewer](https://github.com/klokantech/iiifviewer) and [turban/Leaflet.Zoomify](https://github.com/turban/Leaflet.Zoomify) who have similar plugins which were used in development of Leaflet-IIIF.
 
 ### Options

--- a/leaflet-iiif.js
+++ b/leaflet-iiif.js
@@ -125,7 +125,6 @@ L.TileLayer.Iiif = L.TileLayer.extend({
         if ((data === null || data === undefined || $.isEmptyObject(data))
             && _this._errorHandler !== undefined) {
           _this._errorHandler();
-          throw new Error('The server returned no data to process');
         }
 
         _this.y = data.height;

--- a/leaflet-iiif.js
+++ b/leaflet-iiif.js
@@ -122,9 +122,12 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     // Look for a way to do this without jQuery
     $.getJSON(_this._infoUrl)
       .done(function(data) {
-        if ((data === null || data === undefined || $.isEmptyObject(data))
-            && _this._errorHandler !== undefined) {
-          _this._errorHandler();
+        if (data === null || data === undefined || $.isEmptyObject(data)) {
+          if (_this._errorHandler !== undefined) {
+              _this._errorHandler();
+          }
+
+          throw new Error('The server returned no data to process');
         }
 
         _this.y = data.height;

--- a/leaflet-iiif.js
+++ b/leaflet-iiif.js
@@ -10,7 +10,8 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     tileSize: 256,
     updateWhenIdle: true,
     tileFormat: 'jpg',
-    fitBounds: true
+    fitBounds: true,
+    errorHandler: undefined
   },
 
   initialize: function(url, options) {
@@ -23,6 +24,10 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     // Check for explicit tileSize set
     if (options.tileSize) {
       this._explicitTileSize = true;
+    }
+
+    if (options.errorHandler) {
+      this._errorHandler = options.errorHandler;
     }
 
     options = L.setOptions(this, options);
@@ -117,6 +122,12 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     // Look for a way to do this without jQuery
     $.getJSON(_this._infoUrl)
       .done(function(data) {
+        if ((data === null || data === undefined || $.isEmptyObject(data))
+            && _this._errorHandler !== undefined) {
+          _this._errorHandler();
+          throw new Error('The server returned no data to process');
+        }
+
         _this.y = data.height;
         _this.x = data.width;
 

--- a/spec/LTileLayerIiifSpec.js
+++ b/spec/LTileLayerIiifSpec.js
@@ -29,6 +29,48 @@ describe('L.TileLayer.Iiif', function() {
     expect(typeof (map)).toEqual('object');
   });
 
+  describe('handles data requests', function() {
+    var errorHandler = {
+      errorHandler: function() {
+        return true;
+      },
+      run: function(vals) {
+        var isEmptyObject = Object.keys(vals).length === 0 && vals.constructor === Object;
+        if(vals === null || typeof vals === 'undefined' || isEmptyObject) {
+          this.errorHandler();
+        }
+      }
+    };
+    var iiifLayer, errors, empty, full;
+
+    beforeEach(function() {
+      errors = spyOn(errorHandler, 'errorHandler');
+    });
+
+    it('handles empty data requests', function(done) {
+     empty =  errorHandler.run({});
+     iiifLayer = L.tileLayer.iiif('http://localhost:9876/base/fixtures/mlk_info.json', errorHandler);
+     map.addLayer(iiifLayer);
+
+     iiifLayer.on('load', function() {
+       expect(typeof iiifLayer.options.errorHandler).toBe('function');
+       expect(errors).toHaveBeenCalled();
+       done();
+     });
+    });
+
+    it('it ignores populated data requests', function(done) {
+      full =  errorHandler.run({data: 7});
+      iiifLayer = iiifLayerFactory(errorHandler);
+      map.addLayer(iiifLayer);
+      iiifLayer.on('load', function() {
+        expect(typeof iiifLayer.options.errorHandler).toBe('function');
+        expect(errors).not.toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
   describe('fitBounds', function() {
     var iiifLayer;
 


### PR DESCRIPTION
@mejackreed This was the simplest implementation I could come up with that didn't involve users having to write custom error handling on the window object. It's similar in that it allows the user to pass in their own custom error handler function if the ajax request completes successfully but doesn't return any data. I can add an example block if you like.
