### PR TITLE
Workaround for use Leaflet-IIIF v2.0.1 with Leaflet v0.7.7

### DIFF
--- a/leaflet-iiif.js
+++ b/leaflet-iiif.js
@@ -72,6 +72,9 @@ L.TileLayer.Iiif = L.TileLayer.extend({
       // Set maxZoom for map
       map._layersMaxZoom = _this.maxZoom;
 
+      // Call add TileLayer
+      L.TileLayer.prototype.onAdd.call(_this, map);
+
       // Set minZoom and minNativeZoom based on how the imageSizes match up
       var smallestImage = _this._imageSizes[0];
       var mapSize = _this._map.getSize();
@@ -90,9 +93,6 @@ L.TileLayer.Iiif = L.TileLayer.extend({
       _this.options.minNativeZoom = newMinZoom;
       _this._prev_map_layersMinZoom = _this._map._layersMinZoom;
       _this._map._layersMinZoom = newMinZoom;
-
-      // Call add TileLayer
-      L.TileLayer.prototype.onAdd.call(_this, map);
 
       if (_this.options.fitBounds) {
         _this._fitBounds();
@@ -266,7 +266,6 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     return this._infoToBaseUrl() + '{region}/{size}/{rotation}/{quality}.{format}';
   },
   _isValidTile: function(coords) {
-    var tileBounds = this._tileCoordsToBounds(coords);
     var _this = this;
     var zoom = _this._getZoomForUrl();
     var sizes = _this._tierSizes[zoom];
@@ -282,6 +281,9 @@ L.TileLayer.Iiif = L.TileLayer.extend({
     }else {
       return true;
     }
+  },
+  _tileShouldBeLoaded: function(coords) {
+    return this._isValidTile(coords);
   },
   _getInitialZoom: function (mapSize) {
     var _this = this;

--- a/leaflet-iiif.js
+++ b/leaflet-iiif.js
@@ -201,8 +201,11 @@ L.TileLayer.Iiif = L.TileLayer.extend({
         };
 
         // Calculates maximum native zoom for the layer
-        _this.maxNativeZoom = Math.max(ceilLog2(_this.x / _this.options.tileSize),
-          ceilLog2(_this.y / _this.options.tileSize));
+        _this.maxNativeZoom = Math.max(
+          ceilLog2(_this.x / _this.options.tileSize),
+          ceilLog2(_this.y / _this.options.tileSize),
+          0
+        );
         _this.options.maxNativeZoom = _this.maxNativeZoom;
         
         // Enable zooming further than native if maxZoom option supplied


### PR DESCRIPTION
Leaflet-IIIF v2.0.1 is significantly faster than v0.2.1 when an explicit `tileSize` setting is bigger than the default (https://github.com/mejackreed/Leaflet-IIIF/pull/56 has not been applied to `release-0.2.x`).

Since Leaflet-IIIF v2.0.1 is not compatible with Leaflet v0.7.7, I have written a temporary workaround.

I'm not familiar with Leaflet, so I don't know if there's any problem with this workaround, but please use it if you like.

Example:
- [Leaflet v0.7.7＋Leaflet-IIIF v0.2.1](https://gist.githack.com/2SC1815J/b48c7184b5ce49f6624d04516f0d9dfe/raw/e244846e3a8c45c50c2c01142f35e6fe9ef57128/index_0.7.7_0.2.1.html)
  - OK (but slow; 7 tiles)
- [Leaflet v0.7.7＋Leaflet-IIIF v2.0.1](https://gist.githack.com/2SC1815J/b48c7184b5ce49f6624d04516f0d9dfe/raw/e244846e3a8c45c50c2c01142f35e6fe9ef57128/index_0.7.7_2.0.1_NG.html)
  - NG (`TypeError: _this._map is undefined`)
  - https://github.com/mejackreed/Leaflet-IIIF/blob/v2.0.1/leaflet-iiif.js#L77
- [Leaflet v0.7.7＋Leaflet-IIIF v2.0.1_workaround](https://gist.githack.com/2SC1815J/b48c7184b5ce49f6624d04516f0d9dfe/raw/e244846e3a8c45c50c2c01142f35e6fe9ef57128/index_0.7.7_2.0.1_workaround.html)
  - Looks OK (and fast; 1 tile)
- [Leaflet v1.5.1＋Leaflet-IIIF v2.0.1_workaround](https://gist.githack.com/2SC1815J/b48c7184b5ce49f6624d04516f0d9dfe/raw/e244846e3a8c45c50c2c01142f35e6fe9ef57128/index_1.5.1_2.0.1_workaround.html)
  - Looks OK

(If you have a file cache, it may be difficult to see the difference in reading speed. Please check the "Disable cache" box on the developer tools.)